### PR TITLE
Extended reflection probe options

### DIFF
--- a/LevelPost/LevelConvert.cs
+++ b/LevelPost/LevelConvert.cs
@@ -58,7 +58,7 @@ namespace LevelPost
         /// </summary>
         BoxLavaNormal,
         /// <summary>
-        /// Remove the default probes and convert Box Lava Alient triggers to reflection probes.
+        /// Remove the default probes and convert Box Lava Alien triggers to reflection probes.
         /// </summary>
         BoxLavaAlien,
     }
@@ -78,7 +78,6 @@ namespace LevelPost
         public List<string> ignoreTexDirs;
         //public string bundlePrefix;
         public int texPointPx;
-        public HashSet<string> bundleAudioClips;
         public ReflectionProbeHandling probeHandling;
         public bool boxLavaProbeOneTimeOnly;
         public int probeRes;

--- a/LevelPost/LevelConvert.cs
+++ b/LevelPost/LevelConvert.cs
@@ -26,41 +26,6 @@ namespace LevelPost
         public int changedProbes;
     }
 
-    /// <summary>
-    /// Action to take for Reflection Probes
-    /// </summary>
-    enum ReflectionProbeHandling
-    {
-        /// <summary>
-        /// Do nothing.
-        /// </summary>
-        Keep,
-        /// <summary>
-        /// Remove the default probes.
-        /// </summary>
-        Remove,
-        /// <summary>
-        /// Force on the default probes.
-        /// </summary>
-        Hide,
-        /// <summary>
-        /// Remove the default probes and convert Box Lava Normal triggers to reflection probes.
-        /// </summary>
-        BoxLavaNormal,
-        /// <summary>
-        /// Remove the default probes and convert Box Lava Alient triggers to reflection probes.
-        /// </summary>
-        BoxLavaAlien,
-    }
-
-    class ReflectionProbeHandlingValues
-    {
-        public static ReflectionProbeHandling[] Get()
-        {
-            return (ReflectionProbeHandling[])Enum.GetValues(typeof(ReflectionProbeHandling));
-        }
-    }
-
     class ConvertSettings
     {
         public bool verbose;
@@ -72,9 +37,9 @@ namespace LevelPost
         public int texPointPx;
         public Dictionary<string, string> bundleMaterials;
         public HashSet<string> bundleGameObjects;
-        public HashSet<string> bundleAudioClips;
-        public ReflectionProbeHandling probeHandling;
-        public bool boxLavaProbeOneTimeOnly;
+        public bool defaultProbeRemove;
+        public bool defaultProbeHide;
+        public bool boxLavaNormalProbe;
         public int probeRes;
     }
 
@@ -510,7 +475,6 @@ namespace LevelPost
         private readonly Dictionary<Guid, Vector3> objSize = new Dictionary<Guid, Vector3>();
         private readonly Dictionary<Guid, int> objRptDelay = new Dictionary<Guid, int>();
         private readonly Dictionary<Guid, int> objImportance = new Dictionary<Guid, int>();
-        private readonly Dictionary<Guid, bool> objOneTime = new Dictionary<Guid, bool>();
         private readonly Dictionary<Guid, string> prefabNames = new Dictionary<Guid, string>();
         private readonly Dictionary<string, Guid> newPrefabIds = new Dictionary<string, Guid>();
         private readonly Dictionary<string, string> prefabConvNames = new Dictionary<string, string>()
@@ -526,13 +490,11 @@ namespace LevelPost
             this.log = log;
             this.stats = stats;
 
-            if (settings.probeHandling == ReflectionProbeHandling.Remove
-                || settings.probeHandling == ReflectionProbeHandling.BoxLavaNormal 
-                || settings.probeHandling == ReflectionProbeHandling.BoxLavaAlien)
+            if (settings.defaultProbeRemove)
                 foreach (var cmd in cmds)
                     if ((VT)cmd[0] == VT.CmdGameObjectAddComponent && (string)cmd[3] == "ReflectionProbe")
                         RemoveObj.Add((Guid)cmd[1]);
-            if (settings.probeHandling == ReflectionProbeHandling.BoxLavaNormal || settings.probeHandling == ReflectionProbeHandling.BoxLavaAlien)
+            if (settings.boxLavaNormalProbe)
             {
                 foreach (var cmd in cmds)
                     if ((VT)cmd[0] == VT.CmdGetComponentAtRuntime)
@@ -545,27 +507,20 @@ namespace LevelPost
                         (VT)val[0] == VT.Vector3b &&
                         compObj.TryGetValue((Guid)cmd[1], out Guid obj) &&
                         !objSize.ContainsKey(obj))
-                            objSize.Add(obj, new Vector3() { x = (float)val[1], y = (float)val[2], z = (float)val[3] });
+                        objSize.Add(obj, new Vector3() { x = (float)val[1], y = (float)val[2], z = (float)val[3] });
                     else if ((VT)cmd[0] == VT.CmdGameObjectSetComponentProperty &&
                         (string)cmd[2] == "m_repeat_delay" &&
                         cmd[5] is float val2 &&
                         compObj.TryGetValue((Guid)cmd[1], out Guid obj2) &&
                         !objRptDelay.ContainsKey(obj2))
-                            objRptDelay.Add(obj2, (int)val2);
+                        objRptDelay.Add(obj2, (int)val2);
                     else if ((VT)cmd[0] == VT.CmdGameObjectSetComponentProperty &&
                         (string)cmd[2] == "importance" &&
                         cmd[5] is int val3 &&
                         compObj.TryGetValue((Guid)cmd[1], out Guid obj3) &&
                         !objImportance.ContainsKey(obj3)) {
-                            objImportance.Add(obj3, val3);
-                            RemoveObj.Remove(obj3);
-                    } else if ((VT)cmd[0] == VT.CmdGameObjectSetComponentProperty &&
-                       (string)cmd[2] == "m_one_time" &&
-                       cmd[5] is bool val4 &&
-                       compObj.TryGetValue((Guid)cmd[1], out Guid obj4) &&
-                       !objOneTime.ContainsKey(obj4))
-                    {
-                            objOneTime.Add(obj4, val4);
+                        objImportance.Add(obj3, val3);
+                        RemoveObj.Remove(obj3);
                     }
             }
             return true;
@@ -575,9 +530,9 @@ namespace LevelPost
         {
             if ((VT)cmd[0] == VT.CmdGameObjectSetComponentProperty &&
                 (string)cmd[2] == "m_level_reflection_probes" &&
-                (settings.probeHandling != ReflectionProbeHandling.Keep))
+                (settings.defaultProbeRemove || settings.defaultProbeHide))
             {
-                if (settings.probeHandling == ReflectionProbeHandling.Hide) // no message if also removed
+                if (!settings.defaultProbeRemove) // no message if also removed
                 {
                     int n = ((object[])cmd[5]).Length - 1;
                     //log("Hidden " + n + " probes");
@@ -641,88 +596,70 @@ namespace LevelPost
             }
 
 
-            if ((VT)cmd[0] == VT.CmdInstantiatePrefab)
+            if ((VT)cmd[0] == VT.CmdInstantiatePrefab &&
+                prefabNames.TryGetValue((Guid)cmd[1], out string prefabName) &&
+                prefabName == "entity_TRIGGER_BOX_LAVA_NORMAL" &&
+                settings.boxLavaNormalProbe)
             {
-                string prefabName;
-                objOneTime.TryGetValue((Guid)cmd[2], out bool isOneTime);
-                bool shouldAddPrefab = false;
-                switch(settings.probeHandling)
+                Guid objId = (Guid)cmd[2], transId = (Guid)cmd[3], rpId = Guid.NewGuid();
+                newCmds.Add(new object[] { VT.CmdCreateGameObject, objId, transId });
+                newCmds.Add(new object[] { VT.CmdGameObjectAddComponent, objId, rpId, "ReflectionProbe" });
+                newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "mode", (byte)0, (byte)0,
+                    new object[] { VT.Enum, 0, "UnityEngine.Rendering.ReflectionProbeMode" } });
+                newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "refreshMode", (byte)0, (byte)0,
+                    new object[] { VT.Enum, 0, "UnityEngine.Rendering.ReflectionProbeRefreshMode" } });
+                newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "boxProjection", (byte)0, (byte)0, true });
+                newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "resolution", (byte)0, (byte)0, settings.probeRes });
+                newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "intensity", (byte)0, (byte)0, 1.5f });
+                newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "clearFlags", (byte)0, (byte)0,
+                    new object[] { VT.Enum, 0, "UnityEngine.Rendering.ReflectionProbeClearFlags" } });
+                newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "backgroundColor", (byte)0, (byte)0,
+                    new object[] { VT.Color, 0f, 0f, 0f, 1f } });
+                newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "cullingMask", (byte)0, (byte)0, -134220801 });
+                newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "center", (byte)0, (byte)0,
+                    new Vector3() { x = 0f, y = 0f, z = 0f } });
+                newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "size", (byte)0, (byte)0,
+                    objSize[objId] });
+                newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "farClipPlane", (byte)0, (byte)0, 100f });
+                newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "nearClipPlane", (byte)0, (byte)0, 0.3f });
+                newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "importance", (byte)0, (byte)0, objRptDelay[objId] });
+
+                RemoveObj.Add(objId);
+
+                stats.convertedProbes++;
+
+                return true;
+                /*
+                var prefabId = (Guid)cmd[1];
+                var objId = (Guid)cmd[2];
+                if (prefabNames.TryGetValue(prefabId, out string prefabName))
                 {
-                    case ReflectionProbeHandling.BoxLavaNormal:
-                        shouldAddPrefab = prefabNames.TryGetValue((Guid)cmd[1], out prefabName)
-                            && prefabName == "entity_TRIGGER_BOX_LAVA_NORMAL";
-                        break;
-                    case ReflectionProbeHandling.BoxLavaAlien:
-                        shouldAddPrefab = prefabNames.TryGetValue((Guid)cmd[1], out prefabName)
-                            && prefabName == "entity_TRIGGER_BOX_LAVA_ALIEN";
-                        break;
-                    default:
-                        break;
-                }
-                shouldAddPrefab &= (!settings.boxLavaProbeOneTimeOnly || isOneTime);
-
-                if(shouldAddPrefab)
-                {
-                    Guid objId = (Guid)cmd[2], transId = (Guid)cmd[3], rpId = Guid.NewGuid();
-                    newCmds.Add(new object[] { VT.CmdCreateGameObject, objId, transId });
-                    newCmds.Add(new object[] { VT.CmdGameObjectAddComponent, objId, rpId, "ReflectionProbe" });
-                    newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "mode", (byte)0, (byte)0,
-                        new object[] { VT.Enum, 0, "UnityEngine.Rendering.ReflectionProbeMode" } });
-                    newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "refreshMode", (byte)0, (byte)0,
-                        new object[] { VT.Enum, 0, "UnityEngine.Rendering.ReflectionProbeRefreshMode" } });
-                    newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "boxProjection", (byte)0, (byte)0, true });
-                    newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "resolution", (byte)0, (byte)0, settings.probeRes });
-                    newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "intensity", (byte)0, (byte)0, 1.5f });
-                    newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "clearFlags", (byte)0, (byte)0,
-                        new object[] { VT.Enum, 0, "UnityEngine.Rendering.ReflectionProbeClearFlags" } });
-                    newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "backgroundColor", (byte)0, (byte)0,
-                        new object[] { VT.Color, 0f, 0f, 0f, 1f } });
-                    newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "cullingMask", (byte)0, (byte)0, -134220801 });
-                    newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "center", (byte)0, (byte)0,
-                        new Vector3() { x = 0f, y = 0f, z = 0f } });
-                    newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "size", (byte)0, (byte)0,
-                        objSize[objId] });
-                    newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "farClipPlane", (byte)0, (byte)0, 100f });
-                    newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "nearClipPlane", (byte)0, (byte)0, 0.3f });
-                    newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "importance", (byte)0, (byte)0, objRptDelay[objId] });
-
-                    RemoveObj.Add(objId);
-
-                    stats.convertedProbes++;
-
-                    return true;
-                    /*
-                    var prefabId = (Guid)cmd[1];
-                    var objId = (Guid)cmd[2];
-                    if (prefabNames.TryGetValue(prefabId, out string prefabName))
+                    int idx = 0;
+                    objIdx.TryGetValue(objId, out idx);
+                    string newPrefabName = prefabConvNames[prefabName] + "_" + idx;
+                    if (!settings.bundleGameObjects.Contains(newPrefabName))
                     {
-                        int idx = 0;
-                        objIdx.TryGetValue(objId, out idx);
-                        string newPrefabName = prefabConvNames[prefabName] + "_" + idx;
-                        if (!settings.bundleGameObjects.Contains(newPrefabName))
-                        {
-                            log("Ignored entity " + prefabName + " index " + idx + ", " + newPrefabName + " is not in bundle.");
-                            if (!unconvPrefabs.Contains(prefabName))
-                            { // can't load, do use find prefab after all
-                                unconvPrefabs.Add(prefabName);
-                                newCmds.Add(new object[] { VT.CmdFindPrefabReference, prefabName, prefabId });
-                            }
-                            return false;
+                        log("Ignored entity " + prefabName + " index " + idx + ", " + newPrefabName + " is not in bundle.");
+                        if (!unconvPrefabs.Contains(prefabName))
+                        { // can't load, do use find prefab after all
+                            unconvPrefabs.Add(prefabName);
+                            newCmds.Add(new object[] { VT.CmdFindPrefabReference, prefabName, prefabId });
                         }
-                        if (!newPrefabIds.TryGetValue(newPrefabName, out Guid newPrefabId))
-                        {
-                            newPrefabId = Guid.NewGuid();
-                            newPrefabIds.Add(newPrefabName, newPrefabId);
-                            newCmds.Add(new object[] { VT.CmdLoadAssetFromAssetBundle, newPrefabName, bunRef.GetGuid(newCmds), newPrefabId });
-                        }
-                        newCmds.Add(new object[] { cmd[0], newPrefabId, cmd[2], cmd[3] }); // instantiate new prefab
-                        log("Converted bundle entity " + prefabName + " index " + idx + " to " + newPrefabName);
-                        stats.convertedEntities++;
-                        convObj.Add(objId);
-                        return true;
+                        return false;
                     }
-                    */
+                    if (!newPrefabIds.TryGetValue(newPrefabName, out Guid newPrefabId))
+                    {
+                        newPrefabId = Guid.NewGuid();
+                        newPrefabIds.Add(newPrefabName, newPrefabId);
+                        newCmds.Add(new object[] { VT.CmdLoadAssetFromAssetBundle, newPrefabName, bunRef.GetGuid(newCmds), newPrefabId });
+                    }
+                    newCmds.Add(new object[] { cmd[0], newPrefabId, cmd[2], cmd[3] }); // instantiate new prefab
+                    log("Converted bundle entity " + prefabName + " index " + idx + " to " + newPrefabName);
+                    stats.convertedEntities++;
+                    convObj.Add(objId);
+                    return true;
                 }
+                */
             }
             return false;
         }
@@ -869,7 +806,7 @@ namespace LevelPost
                     mods.Add(new EntityReplaceMod() { bunRef = bufRef });
             }
 
-            if (settings.probeHandling != ReflectionProbeHandling.Keep)
+            if (settings.defaultProbeRemove || settings.defaultProbeHide || settings.boxLavaNormalProbe)
                 mods.Add(new ReflectionProbeMod());
 
             mods.Add(new TexMod());

--- a/LevelPost/LevelConvert.cs
+++ b/LevelPost/LevelConvert.cs
@@ -36,6 +36,41 @@ namespace LevelPost
         public string BundleName { get { return Path.Combine(Dir, OS, Name); } }
     }
 
+    /// <summary>
+    /// Action to take for Reflection Probes
+    /// </summary>
+    enum ReflectionProbeHandling
+    {
+        /// <summary>
+        /// Do nothing.
+        /// </summary>
+        Keep,
+        /// <summary>
+        /// Remove the default probes.
+        /// </summary>
+        Remove,
+        /// <summary>
+        /// Force on the default probes.
+        /// </summary>
+        Hide,
+        /// <summary>
+        /// Remove the default probes and convert Box Lava Normal triggers to reflection probes.
+        /// </summary>
+        BoxLavaNormal,
+        /// <summary>
+        /// Remove the default probes and convert Box Lava Alient triggers to reflection probes.
+        /// </summary>
+        BoxLavaAlien,
+    }
+
+    class ReflectionProbeHandlingValues
+    {
+        public static ReflectionProbeHandling[] Get()
+        {
+            return (ReflectionProbeHandling[])Enum.GetValues(typeof(ReflectionProbeHandling));
+        }
+    }
+
     class ConvertSettings
     {
         //public bool verbose;
@@ -43,9 +78,9 @@ namespace LevelPost
         public List<string> ignoreTexDirs;
         //public string bundlePrefix;
         public int texPointPx;
-        public bool defaultProbeRemove;
-        public bool defaultProbeHide;
-        public bool boxLavaNormalProbe;
+        public HashSet<string> bundleAudioClips;
+        public ReflectionProbeHandling probeHandling;
+        public bool boxLavaProbeOneTimeOnly;
         public int probeRes;
         public List<ConvertBundle> bundles = new List<ConvertBundle>();
     }
@@ -512,6 +547,7 @@ namespace LevelPost
         private readonly Dictionary<Guid, Vector3> objSize = new Dictionary<Guid, Vector3>();
         private readonly Dictionary<Guid, int> objRptDelay = new Dictionary<Guid, int>();
         private readonly Dictionary<Guid, int> objImportance = new Dictionary<Guid, int>();
+        private readonly Dictionary<Guid, bool> objOneTime = new Dictionary<Guid, bool>();
         private readonly Dictionary<Guid, string> prefabNames = new Dictionary<Guid, string>();
         private readonly HashSet<Guid> RemoveObj = new HashSet<Guid>();
         private readonly Dictionary<Guid, Guid> compObj = new Dictionary<Guid, Guid>();
@@ -522,11 +558,13 @@ namespace LevelPost
             this.log = log;
             this.stats = stats;
 
-            if (settings.defaultProbeRemove)
+            if (settings.probeHandling == ReflectionProbeHandling.Remove
+                || settings.probeHandling == ReflectionProbeHandling.BoxLavaNormal 
+                || settings.probeHandling == ReflectionProbeHandling.BoxLavaAlien)
                 foreach (var cmd in cmds)
                     if ((VT)cmd[0] == VT.CmdGameObjectAddComponent && (string)cmd[3] == "ReflectionProbe")
                         RemoveObj.Add((Guid)cmd[1]);
-            if (settings.boxLavaNormalProbe)
+            if (settings.probeHandling == ReflectionProbeHandling.BoxLavaNormal || settings.probeHandling == ReflectionProbeHandling.BoxLavaAlien)
             {
                 foreach (var cmd in cmds)
                     if ((VT)cmd[0] == VT.CmdGetComponentAtRuntime)
@@ -539,20 +577,27 @@ namespace LevelPost
                         (VT)val[0] == VT.Vector3b &&
                         compObj.TryGetValue((Guid)cmd[1], out Guid obj) &&
                         !objSize.ContainsKey(obj))
-                        objSize.Add(obj, new Vector3() { x = (float)val[1], y = (float)val[2], z = (float)val[3] });
+                            objSize.Add(obj, new Vector3() { x = (float)val[1], y = (float)val[2], z = (float)val[3] });
                     else if ((VT)cmd[0] == VT.CmdGameObjectSetComponentProperty &&
                         (string)cmd[2] == "m_repeat_delay" &&
                         cmd[5] is float val2 &&
                         compObj.TryGetValue((Guid)cmd[1], out Guid obj2) &&
                         !objRptDelay.ContainsKey(obj2))
-                        objRptDelay.Add(obj2, (int)val2);
+                            objRptDelay.Add(obj2, (int)val2);
                     else if ((VT)cmd[0] == VT.CmdGameObjectSetComponentProperty &&
                         (string)cmd[2] == "importance" &&
                         cmd[5] is int val3 &&
                         compObj.TryGetValue((Guid)cmd[1], out Guid obj3) &&
                         !objImportance.ContainsKey(obj3)) {
-                        objImportance.Add(obj3, val3);
-                        RemoveObj.Remove(obj3);
+                            objImportance.Add(obj3, val3);
+                            RemoveObj.Remove(obj3);
+                    } else if ((VT)cmd[0] == VT.CmdGameObjectSetComponentProperty &&
+                       (string)cmd[2] == "m_one_time" &&
+                       cmd[5] is bool val4 &&
+                       compObj.TryGetValue((Guid)cmd[1], out Guid obj4) &&
+                       !objOneTime.ContainsKey(obj4))
+                    {
+                            objOneTime.Add(obj4, val4);
                     }
             }
             return true;
@@ -562,9 +607,9 @@ namespace LevelPost
         {
             if ((VT)cmd[0] == VT.CmdGameObjectSetComponentProperty &&
                 (string)cmd[2] == "m_level_reflection_probes" &&
-                (settings.defaultProbeRemove || settings.defaultProbeHide))
+                (settings.probeHandling != ReflectionProbeHandling.Keep))
             {
-                if (!settings.defaultProbeRemove) // no message if also removed
+                if (settings.probeHandling == ReflectionProbeHandling.Hide) // no message if also removed
                 {
                     int n = ((object[])cmd[5]).Length - 1;
                     //log("Hidden " + n + " probes");
@@ -628,70 +673,88 @@ namespace LevelPost
             }
 
 
-            if ((VT)cmd[0] == VT.CmdInstantiatePrefab &&
-                prefabNames.TryGetValue((Guid)cmd[1], out string prefabName) &&
-                prefabName == "entity_TRIGGER_BOX_LAVA_NORMAL" &&
-                settings.boxLavaNormalProbe)
+            if ((VT)cmd[0] == VT.CmdInstantiatePrefab)
             {
-                Guid objId = (Guid)cmd[2], transId = (Guid)cmd[3], rpId = Guid.NewGuid();
-                newCmds.Add(new object[] { VT.CmdCreateGameObject, objId, transId });
-                newCmds.Add(new object[] { VT.CmdGameObjectAddComponent, objId, rpId, "ReflectionProbe" });
-                newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "mode", (byte)0, (byte)0,
-                    new object[] { VT.Enum, 0, "UnityEngine.Rendering.ReflectionProbeMode" } });
-                newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "refreshMode", (byte)0, (byte)0,
-                    new object[] { VT.Enum, 0, "UnityEngine.Rendering.ReflectionProbeRefreshMode" } });
-                newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "boxProjection", (byte)0, (byte)0, true });
-                newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "resolution", (byte)0, (byte)0, settings.probeRes });
-                newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "intensity", (byte)0, (byte)0, 1.5f });
-                newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "clearFlags", (byte)0, (byte)0,
-                    new object[] { VT.Enum, 0, "UnityEngine.Rendering.ReflectionProbeClearFlags" } });
-                newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "backgroundColor", (byte)0, (byte)0,
-                    new object[] { VT.Color, 0f, 0f, 0f, 1f } });
-                newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "cullingMask", (byte)0, (byte)0, -134220801 });
-                newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "center", (byte)0, (byte)0,
-                    new Vector3() { x = 0f, y = 0f, z = 0f } });
-                newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "size", (byte)0, (byte)0,
-                    objSize[objId] });
-                newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "farClipPlane", (byte)0, (byte)0, 100f });
-                newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "nearClipPlane", (byte)0, (byte)0, 0.3f });
-                newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "importance", (byte)0, (byte)0, objRptDelay[objId] });
-
-                RemoveObj.Add(objId);
-
-                stats.convertedProbes++;
-
-                return true;
-                /*
-                var prefabId = (Guid)cmd[1];
-                var objId = (Guid)cmd[2];
-                if (prefabNames.TryGetValue(prefabId, out string prefabName))
+                string prefabName;
+                objOneTime.TryGetValue((Guid)cmd[2], out bool isOneTime);
+                bool shouldAddPrefab = false;
+                switch(settings.probeHandling)
                 {
-                    int idx = 0;
-                    objIdx.TryGetValue(objId, out idx);
-                    string newPrefabName = prefabConvNames[prefabName] + "_" + idx;
-                    if (!settings.bundleGameObjects.Contains(newPrefabName))
-                    {
-                        log("Ignored entity " + prefabName + " index " + idx + ", " + newPrefabName + " is not in bundle.");
-                        if (!unconvPrefabs.Contains(prefabName))
-                        { // can't load, do use find prefab after all
-                            unconvPrefabs.Add(prefabName);
-                            newCmds.Add(new object[] { VT.CmdFindPrefabReference, prefabName, prefabId });
-                        }
-                        return false;
-                    }
-                    if (!newPrefabIds.TryGetValue(newPrefabName, out Guid newPrefabId))
-                    {
-                        newPrefabId = Guid.NewGuid();
-                        newPrefabIds.Add(newPrefabName, newPrefabId);
-                        newCmds.Add(new object[] { VT.CmdLoadAssetFromAssetBundle, newPrefabName, bunRef.GetGuid(newCmds), newPrefabId });
-                    }
-                    newCmds.Add(new object[] { cmd[0], newPrefabId, cmd[2], cmd[3] }); // instantiate new prefab
-                    log("Converted bundle entity " + prefabName + " index " + idx + " to " + newPrefabName);
-                    stats.convertedEntities++;
-                    convObj.Add(objId);
-                    return true;
+                    case ReflectionProbeHandling.BoxLavaNormal:
+                        shouldAddPrefab = prefabNames.TryGetValue((Guid)cmd[1], out prefabName)
+                            && prefabName == "entity_TRIGGER_BOX_LAVA_NORMAL";
+                        break;
+                    case ReflectionProbeHandling.BoxLavaAlien:
+                        shouldAddPrefab = prefabNames.TryGetValue((Guid)cmd[1], out prefabName)
+                            && prefabName == "entity_TRIGGER_BOX_LAVA_ALIEN";
+                        break;
+                    default:
+                        break;
                 }
-                */
+                shouldAddPrefab &= (!settings.boxLavaProbeOneTimeOnly || isOneTime);
+
+                if(shouldAddPrefab)
+                {
+                    Guid objId = (Guid)cmd[2], transId = (Guid)cmd[3], rpId = Guid.NewGuid();
+                    newCmds.Add(new object[] { VT.CmdCreateGameObject, objId, transId });
+                    newCmds.Add(new object[] { VT.CmdGameObjectAddComponent, objId, rpId, "ReflectionProbe" });
+                    newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "mode", (byte)0, (byte)0,
+                        new object[] { VT.Enum, 0, "UnityEngine.Rendering.ReflectionProbeMode" } });
+                    newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "refreshMode", (byte)0, (byte)0,
+                        new object[] { VT.Enum, 0, "UnityEngine.Rendering.ReflectionProbeRefreshMode" } });
+                    newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "boxProjection", (byte)0, (byte)0, true });
+                    newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "resolution", (byte)0, (byte)0, settings.probeRes });
+                    newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "intensity", (byte)0, (byte)0, 1.5f });
+                    newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "clearFlags", (byte)0, (byte)0,
+                        new object[] { VT.Enum, 0, "UnityEngine.Rendering.ReflectionProbeClearFlags" } });
+                    newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "backgroundColor", (byte)0, (byte)0,
+                        new object[] { VT.Color, 0f, 0f, 0f, 1f } });
+                    newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "cullingMask", (byte)0, (byte)0, -134220801 });
+                    newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "center", (byte)0, (byte)0,
+                        new Vector3() { x = 0f, y = 0f, z = 0f } });
+                    newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "size", (byte)0, (byte)0,
+                        objSize[objId] });
+                    newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "farClipPlane", (byte)0, (byte)0, 100f });
+                    newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "nearClipPlane", (byte)0, (byte)0, 0.3f });
+                    newCmds.Add(new object[] { VT.CmdGameObjectSetComponentProperty, rpId, "importance", (byte)0, (byte)0, objRptDelay[objId] });
+
+                    RemoveObj.Add(objId);
+
+                    stats.convertedProbes++;
+
+                    return true;
+                    /*
+                    var prefabId = (Guid)cmd[1];
+                    var objId = (Guid)cmd[2];
+                    if (prefabNames.TryGetValue(prefabId, out string prefabName))
+                    {
+                        int idx = 0;
+                        objIdx.TryGetValue(objId, out idx);
+                        string newPrefabName = prefabConvNames[prefabName] + "_" + idx;
+                        if (!settings.bundleGameObjects.Contains(newPrefabName))
+                        {
+                            log("Ignored entity " + prefabName + " index " + idx + ", " + newPrefabName + " is not in bundle.");
+                            if (!unconvPrefabs.Contains(prefabName))
+                            { // can't load, do use find prefab after all
+                                unconvPrefabs.Add(prefabName);
+                                newCmds.Add(new object[] { VT.CmdFindPrefabReference, prefabName, prefabId });
+                            }
+                            return false;
+                        }
+                        if (!newPrefabIds.TryGetValue(newPrefabName, out Guid newPrefabId))
+                        {
+                            newPrefabId = Guid.NewGuid();
+                            newPrefabIds.Add(newPrefabName, newPrefabId);
+                            newCmds.Add(new object[] { VT.CmdLoadAssetFromAssetBundle, newPrefabName, bunRef.GetGuid(newCmds), newPrefabId });
+                        }
+                        newCmds.Add(new object[] { cmd[0], newPrefabId, cmd[2], cmd[3] }); // instantiate new prefab
+                        log("Converted bundle entity " + prefabName + " index " + idx + " to " + newPrefabName);
+                        stats.convertedEntities++;
+                        convObj.Add(objId);
+                        return true;
+                    }
+                    */
+                }
             }
             return false;
         }
@@ -838,7 +901,7 @@ namespace LevelPost
                     mods.Add(new EntityReplaceMod() { bunRef = bufRef });
             }
 
-            if (settings.defaultProbeRemove || settings.defaultProbeHide || settings.boxLavaNormalProbe)
+            if (settings.probeHandling != ReflectionProbeHandling.Keep)
                 mods.Add(new ReflectionProbeMod());
 
             mods.Add(new TexMod());

--- a/LevelPost/MainWindow.xaml
+++ b/LevelPost/MainWindow.xaml
@@ -6,31 +6,6 @@
         xmlns:local="clr-namespace:LevelPost"
         mc:Ignorable="d"
         Title="LevelPost" Height="459.26" Width="813.795" Icon="icon128.png">
-    <Window.Resources>
-        <ObjectDataProvider x:Key="ReflectionProbeHandling" MethodName="Get" ObjectType="{x:Type local:ReflectionProbeHandlingValues}">
-        </ObjectDataProvider>
-
-        <DataTemplate x:Key="ReflectionProbeDisplay">
-            <TextBlock x:Name="Text" Text="{Binding Path=.}"></TextBlock>
-            <DataTemplate.Triggers>
-                <DataTrigger Binding="{Binding Path=.}" Value="Keep">
-                    <Setter TargetName="Text" Property="Text" Value="Keep"/>
-                </DataTrigger>
-                <DataTrigger Binding="{Binding Path=.}" Value="Hide">
-                    <Setter TargetName="Text" Property="Text" Value="Force always on"/>
-                </DataTrigger>
-                <DataTrigger Binding="{Binding Path=.}" Value="Remove">
-                    <Setter TargetName="Text" Property="Text" Value="Remove All"/>
-                </DataTrigger>
-                <DataTrigger Binding="{Binding Path=.}" Value="BoxLavaNormal">
-                    <Setter TargetName="Text" Property="Text" Value="Replace by converting Box Lava Normal triggers"/>
-                </DataTrigger>
-                <DataTrigger Binding="{Binding Path=.}" Value="BoxLavaAlien">
-                    <Setter TargetName="Text" Property="Text" Value="Replace by converting Box Lava Alien triggers"/>
-                </DataTrigger>
-            </DataTemplate.Triggers>
-        </DataTemplate>
-    </Window.Resources>
     <Grid>
         <TabControl Margin="10,10,8,8">
             <TabItem Header="Level" TabIndex="1">
@@ -64,19 +39,17 @@
             </TabItem>
             <TabItem Header="Reflection Probes" TabIndex="2">
                 <Grid Background="#FFE5E5E5">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="3*"/>
-                        <ColumnDefinition Width="31*"/>
-                    </Grid.ColumnDefinitions>
-                    <Label Content="Default Probes" HorizontalAlignment="Left" Margin="10,14,0,0" VerticalAlignment="Top" Width="103" Padding="0,5,5,5" Grid.ColumnSpan="2"/>
-                    <ComboBox x:Name="DefaultProbes_Menu" ItemsSource="{Binding Source={StaticResource ReflectionProbeHandling}}" ItemTemplate="{StaticResource ReflectionProbeDisplay}" HorizontalAlignment="Left" Margin="113.452,16,0,0" VerticalAlignment="Top" Width="Auto" SelectionChanged="DefaultProbes_Menu_SelectionChanged" Grid.Column="1"></ComboBox>
-                    <CheckBox x:Name="BoxLavaOneTimeProbe" Content="Convert only Box Lava triggers with OneTime set" HorizontalAlignment="Left" Margin="113.452,46,0,0" VerticalAlignment="Top" RenderTransformOrigin="-0.282,-0.333" Click="Field_Click" Grid.Column="1"/>
-                    <Label Content="Resolution" HorizontalAlignment="Left" Margin="10,69,0,0" VerticalAlignment="Top" Width="103" Padding="0,5,5,5" Grid.ColumnSpan="2"/>
-                    <RadioButton x:Name="ProbeRes_128" Content="128" HorizontalAlignment="Left" Margin="113.452,75,0,0" VerticalAlignment="Top" Width="80" GroupName="ProbeRes" Click="Field_Click" Grid.Column="1"/>
-                    <RadioButton x:Name="ProbeRes_256" Content="256" HorizontalAlignment="Left" Margin="198.452,75,0,0" VerticalAlignment="Top" Height="15" Width="80" IsChecked="True" GroupName="ProbeRes" Click="Field_Click" Grid.Column="1" />
-                    <RadioButton x:Name="ProbeRes_512" Content="512" HorizontalAlignment="Left" Margin="283.452,75,0,0" VerticalAlignment="Top" Width="80" GroupName="ProbeRes" Click="Field_Click" Grid.Column="1" />
-                    <RadioButton x:Name="ProbeRes_1024" Content="1024" HorizontalAlignment="Left" Margin="368.452,75,0,0" VerticalAlignment="Top" Width="80" GroupName="ProbeRes" Click="Field_Click" Grid.Column="1" />
-                    <RadioButton x:Name="ProbeRes_2048" Content="2048" HorizontalAlignment="Left" Margin="453.452,75,0,0" VerticalAlignment="Top" Width="80" GroupName="ProbeRes" Click="Field_Click" Grid.Column="1" />
+                    <Label Content="Default Probes" HorizontalAlignment="Left" Margin="10,14,0,0" VerticalAlignment="Top" Width="103" Padding="0,5,5,5"/>
+                    <RadioButton x:Name="DefaultProbes_Keep" Content="Keep" HorizontalAlignment="Left" Margin="182,20,0,0" VerticalAlignment="Top" IsChecked="True" Width="120" GroupName="DefaultProbes" Click="Field_Click" />
+                    <RadioButton x:Name="DefaultProbes_ForceOn" Content="Force always on" HorizontalAlignment="Left" Margin="307,20,0,0" VerticalAlignment="Top" Height="15" Width="120" RenderTransformOrigin="0.76,0.667" GroupName="DefaultProbes" Click="Field_Click" />
+                    <RadioButton x:Name="DefaultProbes_Remove" Content="Remove all" HorizontalAlignment="Left" Margin="432,20,0,0" VerticalAlignment="Top" Width="120" GroupName="DefaultProbes" Click="Field_Click" />
+                    <CheckBox x:Name="BoxLavaNormalProbe" Content="Convert Box Lava Normal trigger to custom Reflection Probe" HorizontalAlignment="Left" Margin="182,46,0,0" VerticalAlignment="Top" RenderTransformOrigin="-0.282,-0.333" Click="Field_Click"/>
+                    <Label Content="Resolution" HorizontalAlignment="Left" Margin="10,69,0,0" VerticalAlignment="Top" Width="103" Padding="0,5,5,5"/>
+                    <RadioButton x:Name="ProbeRes_128" Content="128" HorizontalAlignment="Left" Margin="182,75,0,0" VerticalAlignment="Top" Width="80" GroupName="ProbeRes" Click="Field_Click"/>
+                    <RadioButton x:Name="ProbeRes_256" Content="256" HorizontalAlignment="Left" Margin="267,75,0,0" VerticalAlignment="Top" Height="15" Width="80" IsChecked="True" GroupName="ProbeRes" Click="Field_Click" />
+                    <RadioButton x:Name="ProbeRes_512" Content="512" HorizontalAlignment="Left" Margin="352,75,0,0" VerticalAlignment="Top" Width="80" GroupName="ProbeRes" Click="Field_Click" />
+                    <RadioButton x:Name="ProbeRes_1024" Content="1024" HorizontalAlignment="Left" Margin="437,75,0,0" VerticalAlignment="Top" Width="80" GroupName="ProbeRes" Click="Field_Click" />
+                    <RadioButton x:Name="ProbeRes_2048" Content="2048" HorizontalAlignment="Left" Margin="522,75,0,0" VerticalAlignment="Top" Width="80" GroupName="ProbeRes" Click="Field_Click" />
                 </Grid>
             </TabItem>
             <TabItem Header="Material" TabIndex="2" IsEnabled="False" Visibility="Collapsed">

--- a/LevelPost/MainWindow.xaml
+++ b/LevelPost/MainWindow.xaml
@@ -6,6 +6,31 @@
         xmlns:local="clr-namespace:LevelPost"
         mc:Ignorable="d"
         Title="LevelPost" Height="459.26" Width="813.795" Icon="icon128.png">
+    <Window.Resources>
+        <ObjectDataProvider x:Key="ReflectionProbeHandling" MethodName="Get" ObjectType="{x:Type local:ReflectionProbeHandlingValues}">
+        </ObjectDataProvider>
+
+        <DataTemplate x:Key="ReflectionProbeDisplay">
+            <TextBlock x:Name="Text" Text="{Binding Path=.}"></TextBlock>
+            <DataTemplate.Triggers>
+                <DataTrigger Binding="{Binding Path=.}" Value="Keep">
+                    <Setter TargetName="Text" Property="Text" Value="Keep"/>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding Path=.}" Value="Hide">
+                    <Setter TargetName="Text" Property="Text" Value="Force always on"/>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding Path=.}" Value="Remove">
+                    <Setter TargetName="Text" Property="Text" Value="Remove All"/>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding Path=.}" Value="BoxLavaNormal">
+                    <Setter TargetName="Text" Property="Text" Value="Replace by converting Box Lava Normal triggers"/>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding Path=.}" Value="BoxLavaAlien">
+                    <Setter TargetName="Text" Property="Text" Value="Replace by converting Box Lava Alien triggers"/>
+                </DataTrigger>
+            </DataTemplate.Triggers>
+        </DataTemplate>
+    </Window.Resources>
     <Grid>
         <TabControl Margin="10,10,8,8">
             <TabItem Header="Level" TabIndex="1">
@@ -41,17 +66,19 @@
             </TabItem>
             <TabItem Header="Reflection Probes" TabIndex="2">
                 <Grid Background="#FFE5E5E5">
-                    <Label Content="Default Probes" HorizontalAlignment="Left" Margin="10,14,0,0" VerticalAlignment="Top" Width="103" Padding="0,5,5,5"/>
-                    <RadioButton x:Name="DefaultProbes_Keep" Content="Keep" HorizontalAlignment="Left" Margin="182,20,0,0" VerticalAlignment="Top" IsChecked="True" Width="120" GroupName="DefaultProbes" Click="Field_Click" />
-                    <RadioButton x:Name="DefaultProbes_ForceOn" Content="Force always on" HorizontalAlignment="Left" Margin="307,20,0,0" VerticalAlignment="Top" Height="15" Width="120" RenderTransformOrigin="0.76,0.667" GroupName="DefaultProbes" Click="Field_Click" />
-                    <RadioButton x:Name="DefaultProbes_Remove" Content="Remove all" HorizontalAlignment="Left" Margin="432,20,0,0" VerticalAlignment="Top" Width="120" GroupName="DefaultProbes" Click="Field_Click" />
-                    <CheckBox x:Name="BoxLavaNormalProbe" Content="Convert Box Lava Normal trigger to custom Reflection Probe" HorizontalAlignment="Left" Margin="182,46,0,0" VerticalAlignment="Top" RenderTransformOrigin="-0.282,-0.333" Click="Field_Click"/>
-                    <Label Content="Resolution" HorizontalAlignment="Left" Margin="10,69,0,0" VerticalAlignment="Top" Width="103" Padding="0,5,5,5"/>
-                    <RadioButton x:Name="ProbeRes_128" Content="128" HorizontalAlignment="Left" Margin="182,75,0,0" VerticalAlignment="Top" Width="80" GroupName="ProbeRes" Click="Field_Click"/>
-                    <RadioButton x:Name="ProbeRes_256" Content="256" HorizontalAlignment="Left" Margin="267,75,0,0" VerticalAlignment="Top" Height="15" Width="80" IsChecked="True" GroupName="ProbeRes" Click="Field_Click" />
-                    <RadioButton x:Name="ProbeRes_512" Content="512" HorizontalAlignment="Left" Margin="352,75,0,0" VerticalAlignment="Top" Width="80" GroupName="ProbeRes" Click="Field_Click" />
-                    <RadioButton x:Name="ProbeRes_1024" Content="1024" HorizontalAlignment="Left" Margin="437,75,0,0" VerticalAlignment="Top" Width="80" GroupName="ProbeRes" Click="Field_Click" />
-                    <RadioButton x:Name="ProbeRes_2048" Content="2048" HorizontalAlignment="Left" Margin="522,75,0,0" VerticalAlignment="Top" Width="80" GroupName="ProbeRes" Click="Field_Click" />
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="3*"/>
+                        <ColumnDefinition Width="31*"/>
+                    </Grid.ColumnDefinitions>
+                    <Label Content="Default Probes" HorizontalAlignment="Left" Margin="10,14,0,0" VerticalAlignment="Top" Width="103" Padding="0,5,5,5" Grid.ColumnSpan="2"/>
+                    <ComboBox x:Name="DefaultProbes_Menu" ItemsSource="{Binding Source={StaticResource ReflectionProbeHandling}}" ItemTemplate="{StaticResource ReflectionProbeDisplay}" HorizontalAlignment="Left" Margin="113.452,16,0,0" VerticalAlignment="Top" Width="Auto" SelectionChanged="DefaultProbes_Menu_SelectionChanged" Grid.Column="1"></ComboBox>
+                    <CheckBox x:Name="BoxLavaOneTimeProbe" Content="Convert only Box Lava triggers with OneTime set" HorizontalAlignment="Left" Margin="113.452,46,0,0" VerticalAlignment="Top" RenderTransformOrigin="-0.282,-0.333" Click="Field_Click" Grid.Column="1"/>
+                    <Label Content="Resolution" HorizontalAlignment="Left" Margin="10,69,0,0" VerticalAlignment="Top" Width="103" Padding="0,5,5,5" Grid.ColumnSpan="2"/>
+                    <RadioButton x:Name="ProbeRes_128" Content="128" HorizontalAlignment="Left" Margin="113.452,75,0,0" VerticalAlignment="Top" Width="80" GroupName="ProbeRes" Click="Field_Click" Grid.Column="1"/>
+                    <RadioButton x:Name="ProbeRes_256" Content="256" HorizontalAlignment="Left" Margin="198.452,75,0,0" VerticalAlignment="Top" Height="15" Width="80" IsChecked="True" GroupName="ProbeRes" Click="Field_Click" Grid.Column="1" />
+                    <RadioButton x:Name="ProbeRes_512" Content="512" HorizontalAlignment="Left" Margin="283.452,75,0,0" VerticalAlignment="Top" Width="80" GroupName="ProbeRes" Click="Field_Click" Grid.Column="1" />
+                    <RadioButton x:Name="ProbeRes_1024" Content="1024" HorizontalAlignment="Left" Margin="368.452,75,0,0" VerticalAlignment="Top" Width="80" GroupName="ProbeRes" Click="Field_Click" Grid.Column="1" />
+                    <RadioButton x:Name="ProbeRes_2048" Content="2048" HorizontalAlignment="Left" Margin="453.452,75,0,0" VerticalAlignment="Top" Width="80" GroupName="ProbeRes" Click="Field_Click" Grid.Column="1" />
                 </Grid>
             </TabItem>
             <TabItem Header="Material" TabIndex="2" IsEnabled="False" Visibility="Collapsed">

--- a/LevelPost/MainWindow.xaml
+++ b/LevelPost/MainWindow.xaml
@@ -6,6 +6,31 @@
         xmlns:local="clr-namespace:LevelPost"
         mc:Ignorable="d"
         Title="LevelPost" Height="459.26" Width="813.795" Icon="icon128.png">
+    <Window.Resources>
+        <ObjectDataProvider x:Key="ReflectionProbeHandling" MethodName="Get" ObjectType="{x:Type local:ReflectionProbeHandlingValues}">
+        </ObjectDataProvider>
+
+        <DataTemplate x:Key="ReflectionProbeDisplay">
+            <TextBlock x:Name="Text" Text="{Binding Path=.}"></TextBlock>
+            <DataTemplate.Triggers>
+                <DataTrigger Binding="{Binding Path=.}" Value="Keep">
+                    <Setter TargetName="Text" Property="Text" Value="Keep"/>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding Path=.}" Value="Hide">
+                    <Setter TargetName="Text" Property="Text" Value="Force always on"/>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding Path=.}" Value="Remove">
+                    <Setter TargetName="Text" Property="Text" Value="Remove All"/>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding Path=.}" Value="BoxLavaNormal">
+                    <Setter TargetName="Text" Property="Text" Value="Replace by converting Box Lava Normal triggers"/>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding Path=.}" Value="BoxLavaAlien">
+                    <Setter TargetName="Text" Property="Text" Value="Replace by converting Box Lava Alien triggers"/>
+                </DataTrigger>
+            </DataTemplate.Triggers>
+        </DataTemplate>
+    </Window.Resources>
     <Grid>
         <TabControl Margin="10,10,8,8">
             <TabItem Header="Level" TabIndex="1">
@@ -39,17 +64,19 @@
             </TabItem>
             <TabItem Header="Reflection Probes" TabIndex="2">
                 <Grid Background="#FFE5E5E5">
-                    <Label Content="Default Probes" HorizontalAlignment="Left" Margin="10,14,0,0" VerticalAlignment="Top" Width="103" Padding="0,5,5,5"/>
-                    <RadioButton x:Name="DefaultProbes_Keep" Content="Keep" HorizontalAlignment="Left" Margin="182,20,0,0" VerticalAlignment="Top" IsChecked="True" Width="120" GroupName="DefaultProbes" Click="Field_Click" />
-                    <RadioButton x:Name="DefaultProbes_ForceOn" Content="Force always on" HorizontalAlignment="Left" Margin="307,20,0,0" VerticalAlignment="Top" Height="15" Width="120" RenderTransformOrigin="0.76,0.667" GroupName="DefaultProbes" Click="Field_Click" />
-                    <RadioButton x:Name="DefaultProbes_Remove" Content="Remove all" HorizontalAlignment="Left" Margin="432,20,0,0" VerticalAlignment="Top" Width="120" GroupName="DefaultProbes" Click="Field_Click" />
-                    <CheckBox x:Name="BoxLavaNormalProbe" Content="Convert Box Lava Normal trigger to custom Reflection Probe" HorizontalAlignment="Left" Margin="182,46,0,0" VerticalAlignment="Top" RenderTransformOrigin="-0.282,-0.333" Click="Field_Click"/>
-                    <Label Content="Resolution" HorizontalAlignment="Left" Margin="10,69,0,0" VerticalAlignment="Top" Width="103" Padding="0,5,5,5"/>
-                    <RadioButton x:Name="ProbeRes_128" Content="128" HorizontalAlignment="Left" Margin="182,75,0,0" VerticalAlignment="Top" Width="80" GroupName="ProbeRes" Click="Field_Click"/>
-                    <RadioButton x:Name="ProbeRes_256" Content="256" HorizontalAlignment="Left" Margin="267,75,0,0" VerticalAlignment="Top" Height="15" Width="80" IsChecked="True" GroupName="ProbeRes" Click="Field_Click" />
-                    <RadioButton x:Name="ProbeRes_512" Content="512" HorizontalAlignment="Left" Margin="352,75,0,0" VerticalAlignment="Top" Width="80" GroupName="ProbeRes" Click="Field_Click" />
-                    <RadioButton x:Name="ProbeRes_1024" Content="1024" HorizontalAlignment="Left" Margin="437,75,0,0" VerticalAlignment="Top" Width="80" GroupName="ProbeRes" Click="Field_Click" />
-                    <RadioButton x:Name="ProbeRes_2048" Content="2048" HorizontalAlignment="Left" Margin="522,75,0,0" VerticalAlignment="Top" Width="80" GroupName="ProbeRes" Click="Field_Click" />
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="3*"/>
+                        <ColumnDefinition Width="31*"/>
+                    </Grid.ColumnDefinitions>
+                    <Label Content="Default Probes" HorizontalAlignment="Left" Margin="10,14,0,0" VerticalAlignment="Top" Width="103" Padding="0,5,5,5" Grid.ColumnSpan="2"/>
+                    <ComboBox x:Name="DefaultProbes_Menu" ItemsSource="{Binding Source={StaticResource ReflectionProbeHandling}}" ItemTemplate="{StaticResource ReflectionProbeDisplay}" HorizontalAlignment="Left" Margin="113.452,16,0,0" VerticalAlignment="Top" Width="Auto" SelectionChanged="DefaultProbes_Menu_SelectionChanged" Grid.Column="1"></ComboBox>
+                    <CheckBox x:Name="BoxLavaOneTimeProbe" Content="Convert only Box Lava triggers with OneTime set" HorizontalAlignment="Left" Margin="113.452,46,0,0" VerticalAlignment="Top" RenderTransformOrigin="-0.282,-0.333" Click="Field_Click" Grid.Column="1"/>
+                    <Label Content="Resolution" HorizontalAlignment="Left" Margin="10,69,0,0" VerticalAlignment="Top" Width="103" Padding="0,5,5,5" Grid.ColumnSpan="2"/>
+                    <RadioButton x:Name="ProbeRes_128" Content="128" HorizontalAlignment="Left" Margin="113.452,75,0,0" VerticalAlignment="Top" Width="80" GroupName="ProbeRes" Click="Field_Click" Grid.Column="1"/>
+                    <RadioButton x:Name="ProbeRes_256" Content="256" HorizontalAlignment="Left" Margin="198.452,75,0,0" VerticalAlignment="Top" Height="15" Width="80" IsChecked="True" GroupName="ProbeRes" Click="Field_Click" Grid.Column="1" />
+                    <RadioButton x:Name="ProbeRes_512" Content="512" HorizontalAlignment="Left" Margin="283.452,75,0,0" VerticalAlignment="Top" Width="80" GroupName="ProbeRes" Click="Field_Click" Grid.Column="1" />
+                    <RadioButton x:Name="ProbeRes_1024" Content="1024" HorizontalAlignment="Left" Margin="368.452,75,0,0" VerticalAlignment="Top" Width="80" GroupName="ProbeRes" Click="Field_Click" Grid.Column="1" />
+                    <RadioButton x:Name="ProbeRes_2048" Content="2048" HorizontalAlignment="Left" Margin="453.452,75,0,0" VerticalAlignment="Top" Width="80" GroupName="ProbeRes" Click="Field_Click" Grid.Column="1" />
                 </Grid>
             </TabItem>
             <TabItem Header="Material" TabIndex="2" IsEnabled="False" Visibility="Collapsed">

--- a/LevelPost/MainWindow.xaml.cs
+++ b/LevelPost/MainWindow.xaml.cs
@@ -90,36 +90,12 @@ namespace LevelPost
                         ((TextBox)FindName(prop)).Text = (string)key.GetValue(prop);
                     }
 
-                    DefaultProbes_Menu.SelectedItem = ReflectionProbeHandling.Keep;
-                    if ((int)key.GetValue("DefaultProbesForceOn", 0) != 0)
-                    {
-                        DefaultProbes_Menu.SelectedItem = ReflectionProbeHandling.Hide;
-                    }
-
-                    if ((int)key.GetValue("DefaultProbesRemove", 0) != 0)
-                    {
-                        DefaultProbes_Menu.SelectedItem = ReflectionProbeHandling.Remove;
-                    }
-
-                    // hacky extension of this reg value (flags):
-                    // 0: no effect
-                    // 1: convert box lava normal
-                    // 2: convert box lava alien
-                    // 4: convert only OneTime
-                    var boxLavaRegValue = (int)key.GetValue("BoxLavaNormalProbe", 0);
-                    BoxLavaOneTimeProbe.IsChecked = ((boxLavaRegValue & 4) != 0);
-                    if ((boxLavaRegValue & 2) != 0)
-                    {
-                        DefaultProbes_Menu.SelectedItem = ReflectionProbeHandling.BoxLavaAlien;
-                    }
-                    else if (boxLavaRegValue != 0)
-                    {
-                        DefaultProbes_Menu.SelectedItem = ReflectionProbeHandling.BoxLavaNormal;
-                    }
-
+                    DefaultProbes_ForceOn.IsChecked = (int)key.GetValue("DefaultProbesForceOn", 0) != 0;
+                    DefaultProbes_Remove.IsChecked = (int)key.GetValue("DefaultProbesRemove", 0) != 0;
                     int res = (int)key.GetValue("CustomProbeRes", 256);
                     if (Array.IndexOf(resArray, res) >= 0)
                         ((RadioButton)FindName("ProbeRes_" + res)).IsChecked = true;
+                    BoxLavaNormalProbe.IsChecked = (int)key.GetValue("BoxLavaNormalProbe", 0) != 0;
                 }
                 else
                 {
@@ -345,8 +321,9 @@ namespace LevelPost
                 texPointPx = texPointPx
             };
 
-            settings.probeHandling = (ReflectionProbeHandling)DefaultProbes_Menu.SelectedItem;
-            settings.boxLavaProbeOneTimeOnly = BoxLavaOneTimeProbe.IsChecked.Value;
+            settings.defaultProbeHide = DefaultProbes_ForceOn.IsChecked.Value;
+            settings.defaultProbeRemove = DefaultProbes_Remove.IsChecked.Value;
+            settings.boxLavaNormalProbe = BoxLavaNormalProbe.IsChecked.Value;
             settings.probeRes = 256;
             foreach (var res in resArray)
               if (((RadioButton)FindName("ProbeRes_" + res)).IsChecked.Value)
@@ -432,36 +409,9 @@ namespace LevelPost
             for (int i = 1; i <= texDirCount; i++)
                 key.SetValue("TexDir" + i.ToString(), ((TextBox)this.FindName("TexDir" + i.ToString())).Text);
 
-            switch((ReflectionProbeHandling)DefaultProbes_Menu.SelectedItem)
-            {
-                case ReflectionProbeHandling.Keep:
-                    key.SetValue("DefaultProbesForceOn", 0);
-                    key.SetValue("DefaultProbesRemove", 0);
-                    key.SetValue("BoxLavaNormalProbe", 0);
-                    break;
-                case ReflectionProbeHandling.Hide:
-                    key.SetValue("DefaultProbesForceOn", 1);
-                    key.SetValue("DefaultProbesRemove", 0);
-                    key.SetValue("BoxLavaNormalProbe", 0);
-                    break;
-                case ReflectionProbeHandling.Remove:
-                    key.SetValue("DefaultProbesForceOn", 0);
-                    key.SetValue("DefaultProbesRemove", 1);
-                    key.SetValue("BoxLavaNormalProbe", 0);
-                    break;
-                case ReflectionProbeHandling.BoxLavaNormal:
-                    key.SetValue("DefaultProbesForceOn", 0);
-                    key.SetValue("DefaultProbesRemove", 1);
-                    key.SetValue("BoxLavaNormalProbe", 1 + (BoxLavaOneTimeProbe.IsChecked == true ? 4 : 0));
-                    break;
-                case ReflectionProbeHandling.BoxLavaAlien:
-                    key.SetValue("DefaultProbesForceOn", 0);
-                    key.SetValue("DefaultProbesRemove", 1);
-                    key.SetValue("BoxLavaNormalProbe", 2 + (BoxLavaOneTimeProbe.IsChecked == true ? 4 : 0));
-                    break;
-                default:
-                    break;
-            }
+            key.SetValue("DefaultProbesForceOn", DefaultProbes_ForceOn.IsChecked == true ? 1 : 0);
+            key.SetValue("DefaultProbesRemove", DefaultProbes_Remove.IsChecked == true ? 1 : 0);
+            key.SetValue("BoxLavaNormalProbe", BoxLavaNormalProbe.IsChecked == true ? 1 : 0);
             foreach (var res in resArray)
                 if (((RadioButton)FindName("ProbeRes_" + res)).IsChecked.Value)
                     key.SetValue("CustomProbeRes", res);
@@ -560,11 +510,6 @@ namespace LevelPost
         private void TexPointPx_PreviewTextInput(object sender, TextCompositionEventArgs e)
         {
             e.Handled = e.Text.CompareTo("0") >= 0 && e.Text.CompareTo("9") <= 0;
-        }
-
-        private void DefaultProbes_Menu_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            UpdateAll();
         }
     }
 }

--- a/LevelPost/MainWindow.xaml.cs
+++ b/LevelPost/MainWindow.xaml.cs
@@ -90,12 +90,36 @@ namespace LevelPost
                         ((TextBox)FindName(prop)).Text = (string)key.GetValue(prop);
                     }
 
-                    DefaultProbes_ForceOn.IsChecked = (int)key.GetValue("DefaultProbesForceOn", 0) != 0;
-                    DefaultProbes_Remove.IsChecked = (int)key.GetValue("DefaultProbesRemove", 0) != 0;
+                    DefaultProbes_Menu.SelectedItem = ReflectionProbeHandling.Keep;
+                    if ((int)key.GetValue("DefaultProbesForceOn", 0) != 0)
+                    {
+                        DefaultProbes_Menu.SelectedItem = ReflectionProbeHandling.Hide;
+                    }
+
+                    if ((int)key.GetValue("DefaultProbesRemove", 0) != 0)
+                    {
+                        DefaultProbes_Menu.SelectedItem = ReflectionProbeHandling.Remove;
+                    }
+
+                    // hacky extension of this reg value (flags):
+                    // 0: no effect
+                    // 1: convert box lava normal
+                    // 2: convert box lava alien
+                    // 4: convert only OneTime
+                    var boxLavaRegValue = (int)key.GetValue("BoxLavaNormalProbe", 0);
+                    BoxLavaOneTimeProbe.IsChecked = ((boxLavaRegValue & 4) != 0);
+                    if ((boxLavaRegValue & 2) != 0)
+                    {
+                        DefaultProbes_Menu.SelectedItem = ReflectionProbeHandling.BoxLavaAlien;
+                    }
+                    else if (boxLavaRegValue != 0)
+                    {
+                        DefaultProbes_Menu.SelectedItem = ReflectionProbeHandling.BoxLavaNormal;
+                    }
+
                     int res = (int)key.GetValue("CustomProbeRes", 256);
                     if (Array.IndexOf(resArray, res) >= 0)
                         ((RadioButton)FindName("ProbeRes_" + res)).IsChecked = true;
-                    BoxLavaNormalProbe.IsChecked = (int)key.GetValue("BoxLavaNormalProbe", 0) != 0;
                 }
                 else
                 {
@@ -321,9 +345,8 @@ namespace LevelPost
                 texPointPx = texPointPx
             };
 
-            settings.defaultProbeHide = DefaultProbes_ForceOn.IsChecked.Value;
-            settings.defaultProbeRemove = DefaultProbes_Remove.IsChecked.Value;
-            settings.boxLavaNormalProbe = BoxLavaNormalProbe.IsChecked.Value;
+            settings.probeHandling = (ReflectionProbeHandling)DefaultProbes_Menu.SelectedItem;
+            settings.boxLavaProbeOneTimeOnly = BoxLavaOneTimeProbe.IsChecked.Value;
             settings.probeRes = 256;
             foreach (var res in resArray)
               if (((RadioButton)FindName("ProbeRes_" + res)).IsChecked.Value)
@@ -409,9 +432,36 @@ namespace LevelPost
             for (int i = 1; i <= texDirCount; i++)
                 key.SetValue("TexDir" + i.ToString(), ((TextBox)this.FindName("TexDir" + i.ToString())).Text);
 
-            key.SetValue("DefaultProbesForceOn", DefaultProbes_ForceOn.IsChecked == true ? 1 : 0);
-            key.SetValue("DefaultProbesRemove", DefaultProbes_Remove.IsChecked == true ? 1 : 0);
-            key.SetValue("BoxLavaNormalProbe", BoxLavaNormalProbe.IsChecked == true ? 1 : 0);
+            switch((ReflectionProbeHandling)DefaultProbes_Menu.SelectedItem)
+            {
+                case ReflectionProbeHandling.Keep:
+                    key.SetValue("DefaultProbesForceOn", 0);
+                    key.SetValue("DefaultProbesRemove", 0);
+                    key.SetValue("BoxLavaNormalProbe", 0);
+                    break;
+                case ReflectionProbeHandling.Hide:
+                    key.SetValue("DefaultProbesForceOn", 1);
+                    key.SetValue("DefaultProbesRemove", 0);
+                    key.SetValue("BoxLavaNormalProbe", 0);
+                    break;
+                case ReflectionProbeHandling.Remove:
+                    key.SetValue("DefaultProbesForceOn", 0);
+                    key.SetValue("DefaultProbesRemove", 1);
+                    key.SetValue("BoxLavaNormalProbe", 0);
+                    break;
+                case ReflectionProbeHandling.BoxLavaNormal:
+                    key.SetValue("DefaultProbesForceOn", 0);
+                    key.SetValue("DefaultProbesRemove", 1);
+                    key.SetValue("BoxLavaNormalProbe", 1 + (BoxLavaOneTimeProbe.IsChecked == true ? 4 : 0));
+                    break;
+                case ReflectionProbeHandling.BoxLavaAlien:
+                    key.SetValue("DefaultProbesForceOn", 0);
+                    key.SetValue("DefaultProbesRemove", 1);
+                    key.SetValue("BoxLavaNormalProbe", 2 + (BoxLavaOneTimeProbe.IsChecked == true ? 4 : 0));
+                    break;
+                default:
+                    break;
+            }
             foreach (var res in resArray)
                 if (((RadioButton)FindName("ProbeRes_" + res)).IsChecked.Value)
                     key.SetValue("CustomProbeRes", res);
@@ -510,6 +560,11 @@ namespace LevelPost
         private void TexPointPx_PreviewTextInput(object sender, TextCompositionEventArgs e)
         {
             e.Handled = e.Text.CompareTo("0") >= 0 && e.Text.CompareTo("9") <= 0;
+        }
+
+        private void DefaultProbes_Menu_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            UpdateAll();
         }
     }
 }


### PR DESCRIPTION
With olmod and the community OLE now supporting lava particle effects, there have been times where I wanted to use them while also placing custom reflection probes. Because both of these things use Box Lava trigger entities, this pull request adds options to filter which triggers get converted into reflection probes. The options I added are:
* All Box Lava triggers
* All Box Lava Alien triggers
* Box Lava triggers with OneTime set
* Box Lava Alien triggers with OneTime set

But I also changed these options to always remove the default probes.

Please let me know what you think!